### PR TITLE
fix: add tooltips to all table columns

### DIFF
--- a/src/pages/Table.js
+++ b/src/pages/Table.js
@@ -1,119 +1,208 @@
-import React from "react";
-import { Popup } from "semantic-ui-react";
+import React from 'react';
+import { Popup } from 'semantic-ui-react';
 
 export default class Table extends React.Component {
-	// props.data
-	constructor(props) {
-		super(props);
-		this.getHeader = this.getHeader.bind(this);
-		this.getRowsData = this.getRowsData.bind(this);
-		this.getColumns = this.getColumns.bind(this);
-	}
+  // props.data
+  constructor(props) {
+    super(props);
+    this.getHeader = this.getHeader.bind(this);
+    this.getRowsData = this.getRowsData.bind(this);
+    this.getColumns = this.getColumns.bind(this);
+  }
 
-	getColumns = function () {
-		return ["Sponsors", "Country", "Intervention", "Phase", "Type"];
-	};
+  getColumns = function () {
+    return ['Sponsors', 'Country', 'Intervention', 'Phase', 'Type'];
+  };
 
-	getHeader = function () {
-		var keys = this.getColumns();
-		return keys.map((key) => {
-			return (
-				<th key={key} className="table-title">
-					{key}
-				</th>
-			);
-		});
-	};
+  getHeader = function () {
+    var keys = this.getColumns();
+    return keys.map((key) => {
+      return (
+        <th key={key} className="table-title">
+          {key}
+        </th>
+      );
+    });
+  };
 
-	getRowsData = function () {
-		var items = this.props.data;
-		return items.map((row, index) => {
-			return (
-				<tr key={index} className="record">
-					<RenderRow key={index} data={row} />
-				</tr>
-			);
-		});
-	};
+  getRowsData = function () {
+    var items = this.props.data;
+    return items.map((row, index) => {
+      return (
+        <tr key={index} className="record">
+          <RenderRow key={index} data={row} />
+        </tr>
+      );
+    });
+  };
 
-	render() {
-		return (
-			<div
-				className="table-wrapper"
-				style={{ height: "600px", overflow: "auto" }}
-			>
-				<table className="table">
-					<thead>
-						<tr>{this.getHeader()}</tr>
-					</thead>
-					<tbody>{this.getRowsData()}</tbody>
-				</table>
-			</div>
-		);
-	}
+  render() {
+    return (
+      <div
+        className="table-wrapper"
+        style={{ height: '600px', overflow: 'auto' }}
+      >
+        <table className="table">
+          <thead>
+            <tr>{this.getHeader()}</tr>
+          </thead>
+          <tbody>{this.getRowsData()}</tbody>
+        </table>
+      </div>
+    );
+  }
 }
 
 const RenderRow = (props) => {
-	// props.data
+  // props.data
 
-	return (
-		<>
-			<td>
-				<Popup
-					trigger={
-						<a
-							href={props.data.data_source}
-							target="_blank"
-							rel="noreferrer noopener"
-						>
-							{props.data.sponsors}
-						</a>
-					}
-					content={`${props.data.sponsors.replace(
-						/\w\S*/g,
-						(c) => c.charAt(0).toUpperCase() + c.substr(1)
-					)}`}
-					position="bottom center"
-					basic
-				/>
-			</td>
-
-			<td>
-				<a
-					href={props.data.data_source}
-					target="_blank"
-					rel="noreferrer noopener"
-				>
-					{props.data.countries}
-				</a>
-			</td>
-			<td>
-				<a
-					href={props.data.data_source}
-					target="_blank"
-					rel="noreferrer noopener"
-				>
-					{props.data.intervention}
-				</a>
-			</td>
-			<td>
-				<a
-					href={props.data.data_source}
-					target="_blank"
-					rel="noreferrer noopener"
-				>
-					{props.data.phase}
-				</a>
-			</td>
-			<td>
-				<a
-					href={props.data.data_source}
-					target="_blank"
-					rel="noreferrer noopener"
-				>
-					{props.data.intervention_type}
-				</a>
-			</td>
-		</>
-	);
+  return (
+    <>
+      <td>
+        {props.data.sponsors.length > 10 ? (
+          <Popup
+            trigger={
+              <a
+                href={props.data.data_source}
+                target="_blank"
+                rel="noreferrer noopener"
+              >
+                {props.data.sponsors}
+              </a>
+            }
+            content={`${props.data.sponsors.replace(
+              /\w\S*/g,
+              (c) => c.charAt(0).toUpperCase() + c.substr(1)
+            )}`}
+            position="bottom center"
+            basic
+          />
+        ) : (
+          <a
+            href={props.data.data_source}
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            {props.data.sponsors}
+          </a>
+        )}
+      </td>
+      <td>
+        {props.data.countries.length > 13 ? (
+          <Popup
+            trigger={
+              <a
+                href={props.data.data_source}
+                target="_blank"
+                rel="noreferrer noopener"
+              >
+                {props.data.countries}
+              </a>
+            }
+            content={`${props.data.countries.replace(
+              /\w\S*/g,
+              (c) => c.charAt(0).toUpperCase() + c.substr(1)
+            )}`}
+            position="bottom center"
+            basic
+          />
+        ) : (
+          <a
+            href={props.data.data_source}
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            {props.data.countries}
+          </a>
+        )}
+      </td>
+      <td>
+        {props.data.intervention.length > 14 ? (
+          <Popup
+            trigger={
+              <a
+                href={props.data.data_source}
+                target="_blank"
+                rel="noreferrer noopener"
+              >
+                {props.data.intervention}
+              </a>
+            }
+            content={`${props.data.intervention.replace(
+              /\w\S*/g,
+              (c) => c.charAt(0).toUpperCase() + c.substr(1)
+            )}`}
+            position="bottom center"
+            basic
+          />
+        ) : (
+          <a
+            href={props.data.data_source}
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            {props.data.intervention}
+          </a>
+        )}
+      </td>
+      <td>
+        {props.data.phase.length > 14 ? (
+          <Popup
+            trigger={
+              <a
+                href={props.data.data_source}
+                target="_blank"
+                rel="noreferrer noopener"
+              >
+                {props.data.phase}
+              </a>
+            }
+            content={`${props.data.phase.replace(
+              /\w\S*/g,
+              (c) => c.charAt(0).toUpperCase() + c.substr(1)
+            )}`}
+            position="bottom center"
+            basic
+          />
+        ) : (
+          <a
+            href={props.data.data_source}
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            {props.data.phase}
+          </a>
+        )}
+      </td>
+      <td>
+        {props.data.intervention_type.length > 14 ? (
+          <Popup
+            trigger={
+              <a
+                href={props.data.data_source}
+                target="_blank"
+                rel="noreferrer noopener"
+              >
+                {props.data.intervention_type}
+              </a>
+            }
+            content={`${props.data.intervention_type.replace(
+              /\w\S*/g,
+              (c) => c.charAt(0).toUpperCase() + c.substr(1)
+            )}`}
+            position="bottom center"
+            basic
+          />
+        ) : (
+          <a
+            href={props.data.data_source}
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            {props.data.intervention_type}
+          </a>
+        )}
+      </td>
+    </>
+  );
 };


### PR DESCRIPTION
# Description

Hovering a column name in the table now shows the full entry as a tooltip. If the entry is < 10-14 characters long, then the tooltip does not display.

## Type of change

- [ ] :art: CSS Styling fix
- [x] :ambulance: Bug fix (non-breaking change which fixes an issue)
- [ ] :recycle: :wastebasket: Re-factor, cleanup, un-comment, docstring
- [ ] :sparkles: New feature (non-breaking change which adds functionality)
- [ ] :boom: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Change Status

- [ ] :checkered_flag: Complete, tested, ready to review and merge
- [x] :traffic_light: Complete, but not tested (may need new tests)
- [ ] :construction: WIP work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [x] Manually Functionality Testing
- [ ] Unit Test

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts