### PR TITLE
Fix: adjust count get request for UI counts

### DIFF
--- a/src/components/CountryDropdown.js
+++ b/src/components/CountryDropdown.js
@@ -18,10 +18,8 @@ export default function CountryDropdown({ type, dispatch }) {
 	// Semantic onChange called with SyntheticEvent and all props
 	const handleChange = (evt, { value }) => {
 		// dispatch country filter option
-		console.log("value", value);
 		dispatch({ type: "CHANGE_COUNTRY", payload: value });
 	};
-	console.log("dropdown", dropdown);
 
 	return (
 		<Dropdown

--- a/src/pages/DashTopper.js
+++ b/src/pages/DashTopper.js
@@ -23,10 +23,8 @@ function DashTopper({ filterInfo, dispatch }) {
 
 	useEffect(() => {
 		if (countries && type === "all") {
-			setNumPhase(
-				calcPhases(cards, [`vaccines`, "treatments", "alternatives"])
-			);
-		} else if (countries && type !== "all") {
+			setNumPhase(calcPhases(cards, [`vaccines`, "treatments", "alternatives"]));
+			} else if (countries && type !== "all") {
 			setNumPhase(calcPhases(cards, [`${type}`]));
 		}
 	}, [cards, countries, type]);

--- a/src/pages/VaccineTable.js
+++ b/src/pages/VaccineTable.js
@@ -11,10 +11,11 @@ GOAL:
 */
 
 function VaccineTable({ filterInfo, dispatch }) {
-	const { getTrials, getDashCardsByCountryAndType, getDashCardsGlobal, table, isLoading, count } = useContext(TableContext);
+	const { getTrials, getDashCardsByCountryAndType, getDashCardsGlobal, getDashCardsByTypeGlobal, table, isLoading, count } = useContext(TableContext);
 
 	const { page, country, type } = filterInfo;
 
+	// fetch table data and card totals
 	useEffect(() => {
 		let apiUrl = `api/trials?limit=7&page=${page}`;
 
@@ -27,12 +28,19 @@ function VaccineTable({ filterInfo, dispatch }) {
 		}
 
 		// fetch totals based on filters
-		if (country !== "world" || type !== "all") getDashCardsByCountryAndType(country, type);
 		if (country === "world" && type === "all") getDashCardsGlobal();
-		
+		if (country === 'world' && type !== "all") getDashCardsByTypeGlobal();
+		if (country !== "world") getDashCardsByCountryAndType(country, type);
+
 		// fetch dynamically filtered table results
 		getTrials(apiUrl);
 	}, [filterInfo, country, type]); // when filter info changes, fetch data
+
+
+	useEffect(() => {
+		console.log('test');
+	}, [country, type, getDashCardsGlobal])
+
 
 	return (
 		<div className="trial-padding">

--- a/src/utils/TableContext/TableState.js
+++ b/src/utils/TableContext/TableState.js
@@ -1,4 +1,4 @@
-import React, { createContext, useReducer, useEffect } from "react";
+import React, { createContext, useReducer } from "react";
 
 import {
 	IS_LOADING,
@@ -224,7 +224,6 @@ export const TableState = (props) => {
 				type: GET_DASH_CARDS_BY_TYPE_GLOBAL_SUCCESS,
 				payload: res.data,
 			});
-			console.log("res", res);
 		} catch (e) {
 			console.log("error", e);
 			dispatch({


### PR DESCRIPTION
# Description
When switching between filter types, the card count would get set to 0. This updates the request conditions to make sure counts stay in sync with the filter types.

## Type of change
- [x] :ambulance: Bug fix (non-breaking change which fixes an issue)

## Change Status
- [x] :checkered_flag: Complete, tested, ready to review and merge
- [ ] :traffic_light: Complete, but not tested (may need new tests)
- [ ] :construction: WIP work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?
- [x] Manually Functionality Testing
- [ ] Unit Test

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] There are no merge conflicts